### PR TITLE
fix typo

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -36,7 +36,7 @@ def parse_args():
 
 
 def voc_test(model, data_dir, device, transform):
-    evaluator = VOCAPIEvaluator(data_root=data_dir,
+    evaluator = VOCAPIEvaluator(data_dir=data_dir,
                                 device=device,
                                 transform=transform,
                                 display=True)


### PR DESCRIPTION
When I run the eval process on VOC dataset, an error occurs:
```python
Traceback (most recent call last):
  File "eval.py", line 126, in <module>
    voc_test(model, data_dir, device, transform)
  File "eval.py", line 42, in voc_test
    display=True)
TypeError: __init__() got an unexpected keyword argument 'data_root'
```
I discovered that this was due to a typo and simply fixed it.
Everything is going well now.